### PR TITLE
Refactor Gemini API call and update table header

### DIFF
--- a/app/src/main/java/com/myprojects/knowyouringredients/GeminiClient.java
+++ b/app/src/main/java/com/myprojects/knowyouringredients/GeminiClient.java
@@ -24,7 +24,7 @@ public class GeminiClient {
 
     // IMPORTANT: It is strongly recommended to not hardcode API keys directly in the source code.
     // Consider using a backend proxy or secure build configurations for API key management in production environments.
-    private static final String API_KEY = "AIzaSyDDwF-KJ2VlQF9J0EgIR8WOU5ekWTeemKM";
+    private static final String API_KEY = "";
     private static final String ENDPOINT = "https://generativelanguage.googleapis.com/v1/models/gemini-2.0-flash:generateContent?key=" + API_KEY;
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
 
@@ -39,10 +39,9 @@ public class GeminiClient {
      * via the provided {@link GeminiCallback}.
 
      * @param prompt The main input text/prompt to send to the Gemini model.
-     * @param question This parameter is currently unused in the request construction but is kept for potential future use or context.
      * @param callback The callback to be invoked with the API response or error.
      */
-    public static void fetchAnswer(String prompt, String question, GeminiCallback callback) {
+    public static void fetchAnswer(String prompt, GeminiCallback callback) {
         OkHttpClient client = new OkHttpClient();
 
         try {

--- a/app/src/main/java/com/myprojects/knowyouringredients/TableActivity.java
+++ b/app/src/main/java/com/myprojects/knowyouringredients/TableActivity.java
@@ -25,7 +25,7 @@ public class TableActivity extends AppCompatActivity {
             String[] values = input.split(",");
 
             // add header raw
-            addRow("Text", "Description", true);
+            addRow("Ingredient", "Description", true);
 
             // add data rows
             for (String value : values) {
@@ -46,23 +46,23 @@ public class TableActivity extends AppCompatActivity {
         TextView textView1 = new TextView(this);
         TextView textView2 = new TextView(this);
 
-        String question = "US Politics";
 
+        if(! isHeader){
+            textView1.setText(text);
+            textView2.setText(R.string.fetching_answer_from_gemini);
+            GeminiClient.fetchAnswer(text, new GeminiClient.GeminiCallback() {
+                @Override
+                public void onResponse(String result) {
+                    runOnUiThread(() -> textView2.setText(result));
+                }
 
-        textView1.setText(text);
-        textView2.setText(R.string.fetching_answer_from_gemini);
-        GeminiClient.fetchAnswer(text, question, new GeminiClient.GeminiCallback() {
-            @Override
-            public void onResponse(String result) {
-                runOnUiThread(() -> textView2.setText(result));
-            }
-
-            @SuppressLint("SetTextI18n")
-            @Override
-            public void onError(String error) {
-                runOnUiThread(() -> textView2.setText("Error: " + error));
-            }
-        });
+                @SuppressLint("SetTextI18n")
+                @Override
+                public void onError(String error) {
+                    runOnUiThread(() -> textView2.setText("Error: " + error));
+                }
+            });
+        }
 
 
         textView1.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1));
@@ -72,8 +72,8 @@ public class TableActivity extends AppCompatActivity {
         textView2.setPadding(8, 8, 8, 8);
 
         if (isHeader) {
-            textView1.setText(R.string.keyword);
-            textView2.setText(R.string.description);
+            textView1.setText(text);
+            textView2.setText(description);
             textView1.setTypeface(null, Typeface.BOLD);
             textView2.setTypeface(null, Typeface.BOLD);
             textView1.setBackgroundColor(Color.BLACK);


### PR DESCRIPTION
This commit refactors the `GeminiClient.fetchAnswer` method by removing the unused `question` parameter.

Additionally, the table header in `TableActivity` has been updated:
- The first column header is now "Ingredient" instead of "Text".
- The logic for setting header text has been adjusted to correctly display the passed `text` and `description` values.
- Gemini API calls are now skipped for header rows.
- The hardcoded API key in `GeminiClient` has been removed.